### PR TITLE
Replace direct Header field accesses with accessor methods

### DIFF
--- a/api/proto/node/node_test.go
+++ b/api/proto/node/node_test.go
@@ -60,14 +60,14 @@ func TestConstructBlocksSyncMessage(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
 
 	root := statedb.IntermediateRoot(false)
-	head := &block.Header{
-		Number:  new(big.Int).SetUint64(uint64(10000)),
-		Epoch:   big.NewInt(0),
-		ShardID: 0,
-		Time:    new(big.Int).SetUint64(uint64(100000)),
-		Root:    root,
-	}
-	head.GasLimit = 10000000000
+	head := block.NewHeaderWith().
+		Number(new(big.Int).SetUint64(uint64(10000))).
+		Epoch(big.NewInt(0)).
+		ShardID(0).
+		Time(new(big.Int).SetUint64(uint64(100000))).
+		Root(root).
+		GasLimit(10000000000).
+		Header()
 
 	if _, err := statedb.Commit(false); err != nil {
 		t.Fatalf("statedb.Commit() failed: %s", err)

--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -235,7 +235,7 @@ func (s *Service) GetExplorerBlocks(w http.ResponseWriter, r *http.Request) {
 		}
 		mask, err := bls2.NewMask(pubkeys, nil)
 		if err == nil && accountBlocks[id+1] != nil {
-			err = mask.SetMask(accountBlocks[id+1].Header().LastCommitBitmap)
+			err = mask.SetMask(accountBlocks[id+1].Header().LastCommitBitmap())
 			if err == nil {
 				for _, validator := range committee.NodeList {
 					oneAddress, err := common2.AddressToBech32(validator.EcdsaAddress)

--- a/api/service/explorer/storage_test.go
+++ b/api/service/explorer/storage_test.go
@@ -58,7 +58,7 @@ func TestDump(t *testing.T) {
 	tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), 0, big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 	txs := []*types.Transaction{tx1, tx2, tx3}
 
-	block := types.NewBlock(&block2.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
+	block := types.NewBlock(block2.NewHeaderWith().Number(big.NewInt(314)).Header(), txs, nil, nil, nil)
 	ins := GetStorageInstance("1.1.1.1", "3333", true)
 	ins.Dump(block, uint64(1))
 	db := ins.GetDB()
@@ -116,7 +116,7 @@ func TestUpdateAddressStorage(t *testing.T) {
 	tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), 0, big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 	txs := []*types.Transaction{tx1, tx2, tx3}
 
-	block := types.NewBlock(&block2.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
+	block := types.NewBlock(block2.NewHeaderWith().Number(big.NewInt(314)).Header(), txs, nil, nil, nil)
 	ins := GetStorageInstance("1.1.1.1", "3333", true)
 	ins.Dump(block, uint64(1))
 	db := ins.GetDB()

--- a/api/service/explorer/structs_test.go
+++ b/api/service/explorer/structs_test.go
@@ -20,7 +20,7 @@ func TestGetTransaction(t *testing.T) {
 	tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), 0, big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 	txs := []*types.Transaction{tx1, tx2, tx3}
 
-	block := types.NewBlock(&block2.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
+	block := types.NewBlock(block2.NewHeaderWith().Number(big.NewInt(314)).Header(), txs, nil, nil, nil)
 
 	tx := GetTransaction(tx1, block)
 	assert.Equal(t, tx.ID, tx1.Hash().Hex(), "should be equal tx1.Hash()")

--- a/api/service/resharding/service.go
+++ b/api/service/resharding/service.go
@@ -61,11 +61,11 @@ func (s *Service) Run(stopChan chan struct{}, stoppedChan chan struct{}) {
 func (s *Service) DoService() {
 	tick := time.NewTicker(ReshardingCheckTime)
 	// Get current shard state hash.
-	currentShardStateHash := s.beaconChain.CurrentBlock().Header().ShardStateHash
+	currentShardStateHash := s.beaconChain.CurrentBlock().Header().ShardStateHash()
 	for {
 		select {
 		case <-tick.C:
-			LatestShardStateHash := s.beaconChain.CurrentBlock().Header().ShardStateHash
+			LatestShardStateHash := s.beaconChain.CurrentBlock().Header().ShardStateHash()
 			if currentShardStateHash != LatestShardStateHash {
 				// TODO(minhdoan): Add resharding logic later after modifying the resharding func as it current doesn't calculate the role (leader/validator)
 			}

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -555,7 +555,7 @@ func (ss *StateSync) updateBlockAndStatus(block *types.Block, bc *core.BlockChai
 		return false
 	}
 	ss.syncMux.Lock()
-	if err := worker.UpdateCurrent(block.Header().Coinbase); err != nil {
+	if err := worker.UpdateCurrent(block.Header().Coinbase()); err != nil {
 		utils.Logger().Warn().Err(err).Msg("[SYNC] (*Worker).UpdateCurrent failed")
 	}
 	ss.syncMux.Unlock()

--- a/block/gen_header_json.go
+++ b/block/gen_header_json.go
@@ -32,18 +32,18 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		Hash        common.Hash    `json:"hash"`
 	}
 	var enc Header
-	enc.ParentHash = h.ParentHash
-	enc.Coinbase = h.Coinbase
-	enc.Root = h.Root
-	enc.TxHash = h.TxHash
-	enc.ReceiptHash = h.ReceiptHash
-	enc.Bloom = h.Bloom
-	enc.Number = (*hexutil.Big)(h.Number)
-	enc.GasLimit = hexutil.Uint64(h.GasLimit)
-	enc.GasUsed = hexutil.Uint64(h.GasUsed)
-	enc.Time = (*hexutil.Big)(h.Time)
-	enc.Extra = h.Extra
-	enc.MixDigest = h.MixDigest
+	enc.ParentHash = h.ParentHash()
+	enc.Coinbase = h.Coinbase()
+	enc.Root = h.Root()
+	enc.TxHash = h.TxHash()
+	enc.ReceiptHash = h.ReceiptHash()
+	enc.Bloom = h.Bloom()
+	enc.Number = (*hexutil.Big)(h.Number())
+	enc.GasLimit = hexutil.Uint64(h.GasLimit())
+	enc.GasUsed = hexutil.Uint64(h.GasUsed())
+	enc.Time = (*hexutil.Big)(h.Time())
+	enc.Extra = h.Extra()
+	enc.MixDigest = h.MixDigest()
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -71,47 +71,47 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.ParentHash == nil {
 		return errors.New("missing required field 'parentHash' for Header")
 	}
-	h.ParentHash = *dec.ParentHash
+	h.SetParentHash(*dec.ParentHash)
 	if dec.Coinbase == nil {
 		return errors.New("missing required field 'miner' for Header")
 	}
-	h.Coinbase = *dec.Coinbase
+	h.SetCoinbase(*dec.Coinbase)
 	if dec.Root == nil {
 		return errors.New("missing required field 'stateRoot' for Header")
 	}
-	h.Root = *dec.Root
+	h.SetRoot(*dec.Root)
 	if dec.TxHash == nil {
 		return errors.New("missing required field 'transactionsRoot' for Header")
 	}
-	h.TxHash = *dec.TxHash
+	h.SetTxHash(*dec.TxHash)
 	if dec.ReceiptHash == nil {
 		return errors.New("missing required field 'receiptsRoot' for Header")
 	}
-	h.ReceiptHash = *dec.ReceiptHash
+	h.SetReceiptHash(*dec.ReceiptHash)
 	if dec.Bloom == nil {
 		return errors.New("missing required field 'logsBloom' for Header")
 	}
-	h.Bloom = *dec.Bloom
-	h.Number = (*big.Int)(dec.Number)
+	h.SetBloom(*dec.Bloom)
+	h.SetNumber((*big.Int)(dec.Number))
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'gasLimit' for Header")
 	}
-	h.GasLimit = uint64(*dec.GasLimit)
+	h.SetGasLimit(uint64(*dec.GasLimit))
 	if dec.GasUsed == nil {
 		return errors.New("missing required field 'gasUsed' for Header")
 	}
-	h.GasUsed = uint64(*dec.GasUsed)
+	h.SetGasUsed(uint64(*dec.GasUsed))
 	if dec.Time == nil {
 		return errors.New("missing required field 'timestamp' for Header")
 	}
-	h.Time = (*big.Int)(dec.Time)
+	h.SetTime((*big.Int)(dec.Time))
 	if dec.Extra == nil {
 		return errors.New("missing required field 'extraData' for Header")
 	}
-	h.Extra = *dec.Extra
+	h.SetExtra(*dec.Extra)
 	if dec.MixDigest == nil {
 		return errors.New("missing required field 'mixHash' for Header")
 	}
-	h.MixDigest = *dec.MixDigest
+	h.SetMixDigest(*dec.MixDigest)
 	return nil
 }

--- a/block/header.go
+++ b/block/header.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"io"
 	"math/big"
 	"unsafe"
 
@@ -16,6 +17,30 @@ import (
 
 // Header represents a block header in the Harmony blockchain.
 type Header struct {
+	fields headerFields
+}
+
+// EncodeRLP encodes the header fields into RLP format.
+func (h *Header) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, &h.fields)
+}
+
+// DecodeRLP decodes the given RLP decode stream into the header fields.
+func (h *Header) DecodeRLP(s *rlp.Stream) error {
+	return s.Decode(&h.fields)
+}
+
+// NewHeader creates a new header object.
+func NewHeader() *Header {
+	return &Header{headerFields{
+		Number: new(big.Int),
+		Time:   new(big.Int),
+		ViewID: new(big.Int),
+		Epoch:  new(big.Int),
+	}}
+}
+
+type headerFields struct {
 	ParentHash          common.Hash    `json:"parentHash"       gencodec:"required"`
 	Coinbase            common.Address `json:"miner"            gencodec:"required"`
 	Root                common.Hash    `json:"stateRoot"        gencodec:"required"`
@@ -43,6 +68,301 @@ type Header struct {
 	CrossLinks          []byte      `json:"crossLink"`
 }
 
+// ParentHash is the header hash of the parent block.  For the genesis block
+// which has no parent by definition, this field is zeroed out.
+func (h *Header) ParentHash() common.Hash {
+	return h.fields.ParentHash
+}
+
+// SetParentHash sets the parent hash field.
+func (h *Header) SetParentHash(newParentHash common.Hash) {
+	h.fields.ParentHash = newParentHash
+}
+
+// Coinbase is the address of the node that proposed this block and all
+// transactions in it.
+func (h *Header) Coinbase() common.Address {
+	return h.fields.Coinbase
+}
+
+// SetCoinbase sets the coinbase address field.
+func (h *Header) SetCoinbase(newCoinbase common.Address) {
+	h.fields.Coinbase = newCoinbase
+}
+
+// Root is the state (account) trie root hash.
+func (h *Header) Root() common.Hash {
+	return h.fields.Root
+}
+
+// SetRoot sets the state trie root hash field.
+func (h *Header) SetRoot(newRoot common.Hash) {
+	h.fields.Root = newRoot
+}
+
+// TxHash is the transaction trie root hash.
+func (h *Header) TxHash() common.Hash {
+	return h.fields.TxHash
+}
+
+// SetTxHash sets the transaction trie root hash field.
+func (h *Header) SetTxHash(newTxHash common.Hash) {
+	h.fields.TxHash = newTxHash
+}
+
+// ReceiptHash is the same-shard transaction receipt trie hash.
+func (h *Header) ReceiptHash() common.Hash {
+	return h.fields.ReceiptHash
+}
+
+// SetReceiptHash sets the same-shard transaction receipt trie hash.
+func (h *Header) SetReceiptHash(newReceiptHash common.Hash) {
+	h.fields.ReceiptHash = newReceiptHash
+}
+
+// OutgoingReceiptHash is the egress transaction receipt trie hash.
+func (h *Header) OutgoingReceiptHash() common.Hash {
+	return h.fields.OutgoingReceiptHash
+}
+
+// SetOutgoingReceiptHash sets the egress transaction receipt trie hash.
+func (h *Header) SetOutgoingReceiptHash(newOutgoingReceiptHash common.Hash) {
+	h.fields.OutgoingReceiptHash = newOutgoingReceiptHash
+}
+
+// IncomingReceiptHash is the ingress transaction receipt trie hash.
+func (h *Header) IncomingReceiptHash() common.Hash {
+	return h.fields.IncomingReceiptHash
+}
+
+// SetIncomingReceiptHash sets the ingress transaction receipt trie hash.
+func (h *Header) SetIncomingReceiptHash(newIncomingReceiptHash common.Hash) {
+	h.fields.IncomingReceiptHash = newIncomingReceiptHash
+}
+
+// Bloom is the Bloom filter that indexes accounts and topics logged by smart
+// contract transactions (executions) in this block.
+func (h *Header) Bloom() types.Bloom {
+	return h.fields.Bloom
+}
+
+// SetBloom sets the smart contract log Bloom filter for this block.
+func (h *Header) SetBloom(newBloom types.Bloom) {
+	h.fields.Bloom = newBloom
+}
+
+// Number is the block number.
+//
+// The returned instance is a copy; the caller may do anything with it.
+func (h *Header) Number() *big.Int {
+	return new(big.Int).Set(h.fields.Number)
+}
+
+// SetNumber sets the block number.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetNumber(newNumber *big.Int) {
+	h.fields.Number.Set(newNumber)
+}
+
+// GasLimit is the gas limit for transactions in this block.
+func (h *Header) GasLimit() uint64 {
+	return h.fields.GasLimit
+}
+
+// SetGasLimit sets the gas limit for transactions in this block.
+func (h *Header) SetGasLimit(newGasLimit uint64) {
+	h.fields.GasLimit = newGasLimit
+}
+
+// GasUsed is the amount of gas used by transactions in this block.
+func (h *Header) GasUsed() uint64 {
+	return h.fields.GasUsed
+}
+
+// SetGasUsed sets the amount of gas used by transactions in this block.
+func (h *Header) SetGasUsed(newGasUsed uint64) {
+	h.fields.GasUsed = newGasUsed
+}
+
+// Time is the UNIX timestamp of this block.
+//
+// The returned instance is a copy; the caller may do anything with it.
+func (h *Header) Time() *big.Int {
+	return new(big.Int).Set(h.fields.Time)
+}
+
+// SetTime sets the UNIX timestamp of this block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetTime(newTime *big.Int) {
+	h.fields.Time.Set(newTime)
+}
+
+// Extra is the extra data field of this block.
+//
+// The returned slice is a copy; the caller may do anything with it.
+func (h *Header) Extra() []byte {
+	return append(h.fields.Extra[:0:0], h.fields.Extra...)
+}
+
+// SetExtra sets the extra data field of this block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetExtra(newExtra []byte) {
+	h.fields.Extra = append(newExtra[:0:0], newExtra...)
+}
+
+// MixDigest is the mixhash.
+//
+// This field is a remnant from Ethereum, and Harmony does not use it and always
+// zeroes it out.
+func (h *Header) MixDigest() common.Hash {
+	return h.fields.MixDigest
+}
+
+// SetMixDigest sets the mixhash of this block.
+func (h *Header) SetMixDigest(newMixDigest common.Hash) {
+	h.fields.MixDigest = newMixDigest
+}
+
+// ViewID is the ID of the view in which this block was originally proposed.
+//
+// It normally increases by one for each subsequent block, or by more than one
+// if one or more PBFT/FBFT view changes have occurred.
+//
+// The returned instance is a copy; the caller may do anything with it.
+func (h *Header) ViewID() *big.Int {
+	return new(big.Int).Set(h.fields.ViewID)
+}
+
+// SetViewID sets the view ID in which the block was originally proposed.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetViewID(newViewID *big.Int) {
+	h.fields.ViewID.Set(newViewID)
+}
+
+// Epoch is the epoch number of this block.
+//
+// The returned instance is a copy; the caller may do anything with it.
+func (h *Header) Epoch() *big.Int {
+	return new(big.Int).Set(h.fields.Epoch)
+}
+
+// SetEpoch sets the epoch number of this block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetEpoch(newEpoch *big.Int) {
+	h.fields.Epoch.Set(newEpoch)
+}
+
+// ShardID is the shard ID to which this block belongs.
+func (h *Header) ShardID() uint32 {
+	return h.fields.ShardID
+}
+
+// SetShardID sets the shard ID to which this block belongs.
+func (h *Header) SetShardID(newShardID uint32) {
+	h.fields.ShardID = newShardID
+}
+
+// LastCommitSignature is the FBFT commit group signature for the last block.
+func (h *Header) LastCommitSignature() [96]byte {
+	return h.fields.LastCommitSignature
+}
+
+// SetLastCommitSignature sets the FBFT commit group signature for the last
+// block.
+func (h *Header) SetLastCommitSignature(newLastCommitSignature [96]byte) {
+	h.fields.LastCommitSignature = newLastCommitSignature
+}
+
+// LastCommitBitmap is the signatory bitmap of the previous block.  Bit
+// positions index into committee member array.
+//
+// The returned slice is a copy; the caller may do anything with it.
+func (h *Header) LastCommitBitmap() []byte {
+	return append(h.fields.LastCommitBitmap[:0:0], h.fields.LastCommitBitmap...)
+}
+
+// SetLastCommitBitmap sets the signatory bitmap of the previous block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetLastCommitBitmap(newLastCommitBitmap []byte) {
+	h.fields.LastCommitBitmap = append(newLastCommitBitmap[:0:0], newLastCommitBitmap...)
+}
+
+// ShardStateHash is the shard state hash.
+func (h *Header) ShardStateHash() common.Hash {
+	return h.fields.ShardStateHash
+}
+
+// SetShardStateHash sets the shard state hash.
+func (h *Header) SetShardStateHash(newShardStateHash common.Hash) {
+	h.fields.ShardStateHash = newShardStateHash
+}
+
+// Vrf is the output of the VRF for the epoch.
+//
+// The returned slice is a copy; the caller may do anything with it.
+func (h *Header) Vrf() []byte {
+	return append(h.fields.Vrf[:0:0], h.fields.Vrf...)
+}
+
+// SetVrf sets the output of the VRF for the epoch.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetVrf(newVrf []byte) {
+	h.fields.Vrf = append(newVrf[:0:0], newVrf...)
+}
+
+// Vdf is the output of the VDF for the epoch.
+//
+// The returned slice is a copy; the caller may do anything with it.
+func (h *Header) Vdf() []byte {
+	return append(h.fields.Vdf[:0:0], h.fields.Vdf...)
+}
+
+// SetVdf sets the output of the VDF for the epoch.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetVdf(newVdf []byte) {
+	h.fields.Vdf = append(newVdf[:0:0], newVdf...)
+}
+
+// ShardState is the RLP-encoded form of shard state (list of committees) for
+// the next epoch.
+//
+// The returned slice is a copy; the caller may do anything with it.
+func (h *Header) ShardState() []byte {
+	return append(h.fields.ShardState[:0:0], h.fields.ShardState...)
+}
+
+// SetShardState sets the RLP-encoded form of shard state
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetShardState(newShardState []byte) {
+	h.fields.ShardState = append(newShardState[:0:0], newShardState...)
+}
+
+// CrossLinks is the RLP-encoded form of non-beacon block headers chosen to be
+// canonical by the beacon committee.  This field is present only on beacon
+// chain block headers.
+//
+// The returned slice is a copy; the caller may do anything with it.
+func (h *Header) CrossLinks() []byte {
+	return append(h.fields.CrossLinks[:0:0], h.fields.CrossLinks...)
+}
+
+// SetCrossLinks sets the RLP-encoded form of non-beacon block headers chosen to
+// be canonical by the beacon committee.
+//
+// It stores a copy; the caller may freely modify the original.
+func (h *Header) SetCrossLinks(newCrossLinks []byte) {
+	h.fields.CrossLinks = append(newCrossLinks[:0:0], newCrossLinks...)
+}
+
 // field type overrides for gencodec
 type headerMarshaling struct {
 	Difficulty *hexutil.Big
@@ -64,7 +384,7 @@ func (h *Header) Hash() common.Hash {
 // to approximate and limit the memory consumption of various caches.
 func (h *Header) Size() common.StorageSize {
 	// TODO: update with new fields
-	return common.StorageSize(unsafe.Sizeof(*h)) + common.StorageSize(len(h.Extra)+(h.Number.BitLen()+h.Time.BitLen())/8)
+	return common.StorageSize(unsafe.Sizeof(*h)) + common.StorageSize(len(h.Extra())+(h.Number().BitLen()+h.Time().BitLen())/8)
 }
 
 // Logger returns a sub-logger with block contexts added.
@@ -72,9 +392,9 @@ func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 	nlogger := logger.
 		With().
 		Str("blockHash", h.Hash().Hex()).
-		Uint32("blockShard", h.ShardID).
-		Uint64("blockEpoch", h.Epoch.Uint64()).
-		Uint64("blockNumber", h.Number.Uint64()).
+		Uint32("blockShard", h.ShardID()).
+		Uint64("blockEpoch", h.Epoch().Uint64()).
+		Uint64("blockNumber", h.Number().Uint64()).
 		Logger()
 	return &nlogger
 }
@@ -82,9 +402,202 @@ func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 // GetShardState returns the deserialized shard state object.
 func (h *Header) GetShardState() (shard.State, error) {
 	shardState := shard.State{}
-	err := rlp.DecodeBytes(h.ShardState, &shardState)
+	err := rlp.DecodeBytes(h.ShardState(), &shardState)
 	if err != nil {
 		return nil, err
 	}
 	return shardState, nil
+}
+
+// HeaderFieldSetter is a header field setter.
+//
+// See NewHeaderWith for how it is used.
+type HeaderFieldSetter struct {
+	h *Header
+}
+
+// NewHeaderWith creates a new header and returns its field setter context.
+//
+// Call a chain of setters on the returned field setter, followed by a call of
+// Header method.  Example:
+//
+//	header := NewHeaderWith().
+//		ParentHash(parent.Hash()).
+//		Epoch(parent.Epoch()).
+//		ShardID(parent.ShardID()).
+//		Number(new(big.Int).Add(parent.Number(), big.NewInt(1)).
+//		Header()
+func NewHeaderWith() *HeaderFieldSetter {
+	return (*HeaderFieldSetter)(&HeaderFieldSetter{h: NewHeader()})
+}
+
+// ParentHash sets the parent hash field.
+func (s HeaderFieldSetter) ParentHash(newParentHash common.Hash) HeaderFieldSetter {
+	s.h.SetParentHash(newParentHash)
+	return s
+}
+
+// Coinbase sets the coinbase address field.
+func (s HeaderFieldSetter) Coinbase(newCoinbase common.Address) HeaderFieldSetter {
+	s.h.SetCoinbase(newCoinbase)
+	return s
+}
+
+// Root sets the state trie root hash field.
+func (s HeaderFieldSetter) Root(newRoot common.Hash) HeaderFieldSetter {
+	s.h.SetRoot(newRoot)
+	return s
+}
+
+// TxHash sets the transaction trie root hash field.
+func (s HeaderFieldSetter) TxHash(newTxHash common.Hash) HeaderFieldSetter {
+	s.h.SetTxHash(newTxHash)
+	return s
+}
+
+// ReceiptHash sets the same-shard transaction receipt trie hash.
+func (s HeaderFieldSetter) ReceiptHash(newReceiptHash common.Hash) HeaderFieldSetter {
+	s.h.SetReceiptHash(newReceiptHash)
+	return s
+}
+
+// OutgoingReceiptHash sets the egress transaction receipt trie hash.
+func (s HeaderFieldSetter) OutgoingReceiptHash(newOutgoingReceiptHash common.Hash) HeaderFieldSetter {
+	s.h.SetOutgoingReceiptHash(newOutgoingReceiptHash)
+	return s
+}
+
+// IncomingReceiptHash sets the ingress transaction receipt trie hash.
+func (s HeaderFieldSetter) IncomingReceiptHash(newIncomingReceiptHash common.Hash) HeaderFieldSetter {
+	s.h.SetIncomingReceiptHash(newIncomingReceiptHash)
+	return s
+}
+
+// Bloom sets the smart contract log Bloom filter for this block.
+func (s HeaderFieldSetter) Bloom(newBloom types.Bloom) HeaderFieldSetter {
+	s.h.SetBloom(newBloom)
+	return s
+}
+
+// Number sets the block number.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) Number(newNumber *big.Int) HeaderFieldSetter {
+	s.h.SetNumber(newNumber)
+	return s
+}
+
+// GasLimit sets the gas limit for transactions in this block.
+func (s HeaderFieldSetter) GasLimit(newGasLimit uint64) HeaderFieldSetter {
+	s.h.SetGasLimit(newGasLimit)
+	return s
+}
+
+// GasUsed sets the amount of gas used by transactions in this block.
+func (s HeaderFieldSetter) GasUsed(newGasUsed uint64) HeaderFieldSetter {
+	s.h.SetGasUsed(newGasUsed)
+	return s
+}
+
+// Time sets the UNIX timestamp of this block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) Time(newTime *big.Int) HeaderFieldSetter {
+	s.h.SetTime(newTime)
+	return s
+}
+
+// Extra sets the extra data field of this block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) Extra(newExtra []byte) HeaderFieldSetter {
+	s.h.SetExtra(newExtra)
+	return s
+}
+
+// MixDigest sets the mixhash of this block.
+func (s HeaderFieldSetter) MixDigest(newMixDigest common.Hash) HeaderFieldSetter {
+	s.h.SetMixDigest(newMixDigest)
+	return s
+}
+
+// ViewID sets the view ID in which the block was originally proposed.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) ViewID(newViewID *big.Int) HeaderFieldSetter {
+	s.h.SetViewID(newViewID)
+	return s
+}
+
+// Epoch sets the epoch number of this block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) Epoch(newEpoch *big.Int) HeaderFieldSetter {
+	s.h.SetEpoch(newEpoch)
+	return s
+}
+
+// ShardID sets the shard ID to which this block belongs.
+func (s HeaderFieldSetter) ShardID(newShardID uint32) HeaderFieldSetter {
+	s.h.SetShardID(newShardID)
+	return s
+}
+
+// LastCommitSignature sets the FBFT commit group signature for the last block.
+func (s HeaderFieldSetter) LastCommitSignature(newLastCommitSignature [96]byte) HeaderFieldSetter {
+	s.h.SetLastCommitSignature(newLastCommitSignature)
+	return s
+}
+
+// LastCommitBitmap sets the signatory bitmap of the previous block.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) LastCommitBitmap(newLastCommitBitmap []byte) HeaderFieldSetter {
+	s.h.SetLastCommitBitmap(newLastCommitBitmap)
+	return s
+}
+
+// ShardStateHash sets the shard state hash.
+func (s HeaderFieldSetter) ShardStateHash(newShardStateHash common.Hash) HeaderFieldSetter {
+	s.h.SetShardStateHash(newShardStateHash)
+	return s
+}
+
+// Vrf sets the output of the VRF for the epoch.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) Vrf(newVrf []byte) HeaderFieldSetter {
+	s.h.SetVrf(newVrf)
+	return s
+}
+
+// Vdf sets the output of the VDF for the epoch.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) Vdf(newVdf []byte) HeaderFieldSetter {
+	s.h.SetVdf(newVdf)
+	return s
+}
+
+// ShardState sets the RLP-encoded form of shard state
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) ShardState(newShardState []byte) HeaderFieldSetter {
+	s.h.SetShardState(newShardState)
+	return s
+}
+
+// CrossLinks sets the RLP-encoded form of non-beacon block headers chosen to be
+// canonical by the beacon committee.
+//
+// It stores a copy; the caller may freely modify the original.
+func (s HeaderFieldSetter) CrossLinks(newCrossLinks []byte) HeaderFieldSetter {
+	s.h.SetCrossLinks(newCrossLinks)
+	return s
+}
+
+// Header returns the header whose fields have been set.  Call this at the end
+// of a field setter chain.
+func (s HeaderFieldSetter) Header() *Header {
+	return s.h
 }

--- a/block/header.go
+++ b/block/header.go
@@ -162,7 +162,7 @@ func (h *Header) Number() *big.Int {
 //
 // It stores a copy; the caller may freely modify the original.
 func (h *Header) SetNumber(newNumber *big.Int) {
-	h.fields.Number.Set(newNumber)
+	h.fields.Number = new(big.Int).Set(newNumber)
 }
 
 // GasLimit is the gas limit for transactions in this block.
@@ -196,7 +196,7 @@ func (h *Header) Time() *big.Int {
 //
 // It stores a copy; the caller may freely modify the original.
 func (h *Header) SetTime(newTime *big.Int) {
-	h.fields.Time.Set(newTime)
+	h.fields.Time = new(big.Int).Set(newTime)
 }
 
 // Extra is the extra data field of this block.
@@ -240,7 +240,7 @@ func (h *Header) ViewID() *big.Int {
 //
 // It stores a copy; the caller may freely modify the original.
 func (h *Header) SetViewID(newViewID *big.Int) {
-	h.fields.ViewID.Set(newViewID)
+	h.fields.ViewID = new(big.Int).Set(newViewID)
 }
 
 // Epoch is the epoch number of this block.
@@ -254,7 +254,7 @@ func (h *Header) Epoch() *big.Int {
 //
 // It stores a copy; the caller may freely modify the original.
 func (h *Header) SetEpoch(newEpoch *big.Int) {
-	h.fields.Epoch.Set(newEpoch)
+	h.fields.Epoch = new(big.Int).Set(newEpoch)
 }
 
 // ShardID is the shard ID to which this block belongs.

--- a/contracts/contract_caller.go
+++ b/contracts/contract_caller.go
@@ -33,7 +33,7 @@ func NewContractCaller(bc *core.BlockChain, config *params.ChainConfig) *Contrac
 // CallContract calls a contracts with the specified transaction.
 func (cc *ContractCaller) CallContract(tx *types.Transaction) ([]byte, error) {
 	currBlock := cc.blockchain.CurrentBlock()
-	msg, err := tx.AsMessage(types.MakeSigner(cc.config, currBlock.Header().Number))
+	msg, err := tx.AsMessage(types.MakeSigner(cc.config, currBlock.Header().Number()))
 	if err != nil {
 		utils.GetLogInstance().Error("[ABI] Failed to convert transaction to message", "error", err)
 		return []byte{}, err

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -251,7 +251,7 @@ func IsEpochLastBlock(block *types.Block) bool {
 // IsEpochLastBlockByHeader returns whether this block is the last block of an epoch
 // given block header
 func IsEpochLastBlockByHeader(header *block.Header) bool {
-	return ShardingSchedule.IsLastBlock(header.Number.Uint64())
+	return ShardingSchedule.IsLastBlock(header.Number().Uint64())
 }
 
 func (bc *BlockChain) getProcInterrupt() bool {
@@ -309,15 +309,15 @@ func (bc *BlockChain) loadLastState() error {
 	// Issue a status log for the user
 	currentFastBlock := bc.CurrentFastBlock()
 
-	headerTd := bc.GetTd(currentHeader.Hash(), currentHeader.Number.Uint64())
+	headerTd := bc.GetTd(currentHeader.Hash(), currentHeader.Number().Uint64())
 	blockTd := bc.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
 	fastTd := bc.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64())
 
 	utils.Logger().Info().
-		Str("number", currentHeader.Number.String()).
+		Str("number", currentHeader.Number().String()).
 		Str("hash", currentHeader.Hash().Hex()).
 		Str("td", headerTd.String()).
-		Str("age", common.PrettyAge(time.Unix(currentHeader.Time.Int64(), 0)).String()).
+		Str("age", common.PrettyAge(time.Unix(currentHeader.Time().Int64(), 0)).String()).
 		Msg("Loaded most recent local header")
 	utils.Logger().Info().
 		Str("number", currentBlock.Number().String()).
@@ -361,8 +361,8 @@ func (bc *BlockChain) SetHead(head uint64) error {
 	bc.shardStateCache.Purge()
 
 	// Rewind the block chain, ensuring we don't end up with a stateless head block
-	if currentBlock := bc.CurrentBlock(); currentBlock != nil && currentHeader.Number.Uint64() < currentBlock.NumberU64() {
-		bc.currentBlock.Store(bc.GetBlock(currentHeader.Hash(), currentHeader.Number.Uint64()))
+	if currentBlock := bc.CurrentBlock(); currentBlock != nil && currentHeader.Number().Uint64() < currentBlock.NumberU64() {
+		bc.currentBlock.Store(bc.GetBlock(currentHeader.Hash(), currentHeader.Number().Uint64()))
 	}
 	if currentBlock := bc.CurrentBlock(); currentBlock != nil {
 		if _, err := state.New(currentBlock.Root(), bc.stateCache); err != nil {
@@ -371,8 +371,8 @@ func (bc *BlockChain) SetHead(head uint64) error {
 		}
 	}
 	// Rewind the fast block in a simpleton way to the target head
-	if currentFastBlock := bc.CurrentFastBlock(); currentFastBlock != nil && currentHeader.Number.Uint64() < currentFastBlock.NumberU64() {
-		bc.currentFastBlock.Store(bc.GetBlock(currentHeader.Hash(), currentHeader.Number.Uint64()))
+	if currentFastBlock := bc.CurrentFastBlock(); currentFastBlock != nil && currentHeader.Number().Uint64() < currentFastBlock.NumberU64() {
+		bc.currentFastBlock.Store(bc.GetBlock(currentHeader.Hash(), currentHeader.Number().Uint64()))
 	}
 	// If either blocks reached nil, reset to the genesis state
 	if currentBlock := bc.CurrentBlock(); currentBlock == nil {
@@ -825,7 +825,7 @@ func (bc *BlockChain) Rollback(chain []common.Hash) {
 
 		currentHeader := bc.hc.CurrentHeader()
 		if currentHeader != nil && currentHeader.Hash() == hash {
-			bc.hc.SetCurrentHeader(bc.GetHeader(currentHeader.ParentHash, currentHeader.Number.Uint64()-1))
+			bc.hc.SetCurrentHeader(bc.GetHeader(currentHeader.ParentHash(), currentHeader.Number().Uint64()-1))
 		}
 		if currentFastBlock := bc.CurrentFastBlock(); currentFastBlock != nil && currentFastBlock.Hash() == hash {
 			newFastBlock := bc.GetBlock(currentFastBlock.ParentHash(), currentFastBlock.NumberU64()-1)
@@ -1032,7 +1032,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 			}
 			// Find the next state trie we need to commit
 			header := bc.GetHeaderByNumber(current - triesInMemory)
-			chosen := header.Number.Uint64()
+			chosen := header.Number().Uint64()
 
 			// If we exceeded out time allowance, flush an entire trie to disk
 			if bc.gcproc > bc.cacheConfig.TrieTimeLimit {
@@ -1046,7 +1046,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 						Msg("State in memory for too long, committing")
 				}
 				// Flush an entire trie and restart the counters
-				triedb.Commit(header.Root, true)
+				triedb.Commit(header.Root(), true)
 				lastWrite = chosen
 				bc.gcproc = 0
 			}
@@ -1066,7 +1066,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 	batch := bc.db.NewBatch()
 	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
 
-	epoch := block.Header().Epoch
+	epoch := block.Header().Epoch()
 	shardingConfig := ShardingSchedule.InstanceForEpoch(epoch)
 	shardNum := int(shardingConfig.NumShards())
 	for i := 0; i < shardNum; i++ {
@@ -1129,13 +1129,13 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			header := block.Header()
 			header.Logger(utils.Logger()).Info().
 				Int("segmentIndex", idx).
-				Str("parentHash", header.ParentHash.Hex()).
+				Str("parentHash", header.ParentHash().Hex()).
 				Msg("added block to chain")
 
 				// TODO: move into WriteBlockWithState
-			if header.ShardStateHash != (common.Hash{}) {
-				epoch := new(big.Int).Add(header.Epoch, common.Big1)
-				err = bc.WriteShardStateBytes(epoch, header.ShardState)
+			if header.ShardStateHash() != (common.Hash{}) {
+				epoch := new(big.Int).Add(header.Epoch(), common.Big1)
+				err = bc.WriteShardStateBytes(epoch, header.ShardState())
 				if err != nil {
 					header.Logger(utils.Logger()).Warn().Err(err).Msg("cannot store shard state")
 					return n, err
@@ -1143,9 +1143,9 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			}
 
 			// TODO: move into WriteBlockWithState
-			if len(header.CrossLinks) > 0 {
+			if len(header.CrossLinks()) > 0 {
 				crossLinks := &types.CrossLinks{}
-				err = rlp.DecodeBytes(header.CrossLinks, crossLinks)
+				err = rlp.DecodeBytes(header.CrossLinks(), crossLinks)
 				if err != nil {
 					header.Logger(utils.Logger()).Warn().Err(err).Msg("[insertChain] cannot parse cross links")
 					return n, err
@@ -1365,19 +1365,19 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 		//check non zero VRF field in header and add to local db
 		if len(block.Vrf()) > 0 {
-			vrfBlockNumbers, _ := bc.ReadEpochVrfBlockNums(block.Header().Epoch)
+			vrfBlockNumbers, _ := bc.ReadEpochVrfBlockNums(block.Header().Epoch())
 			if (len(vrfBlockNumbers) > 0) && (vrfBlockNumbers[len(vrfBlockNumbers)-1] == block.NumberU64()) {
 				utils.Logger().Error().
 					Str("number", chain[i].Number().String()).
-					Str("epoch", block.Header().Epoch.String()).
+					Str("epoch", block.Header().Epoch().String()).
 					Msg("VRF block number is already in local db")
 			} else {
 				vrfBlockNumbers = append(vrfBlockNumbers, block.NumberU64())
-				err = bc.WriteEpochVrfBlockNums(block.Header().Epoch, vrfBlockNumbers)
+				err = bc.WriteEpochVrfBlockNums(block.Header().Epoch(), vrfBlockNumbers)
 				if err != nil {
 					utils.Logger().Error().
 						Str("number", chain[i].Number().String()).
-						Str("epoch", block.Header().Epoch.String()).
+						Str("epoch", block.Header().Epoch().String()).
 						Msg("failed to write VRF block number to local db")
 				}
 			}
@@ -1385,11 +1385,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 
 		//check non zero Vdf in header and add to local db
 		if len(block.Vdf()) > 0 {
-			err = bc.WriteEpochVdfBlockNum(block.Header().Epoch, block.Number())
+			err = bc.WriteEpochVdfBlockNum(block.Header().Epoch(), block.Number())
 			if err != nil {
 				utils.Logger().Error().
 					Str("number", chain[i].Number().String()).
-					Str("epoch", block.Header().Epoch.String()).
+					Str("epoch", block.Header().Epoch().String()).
 					Msg("failed to write VDF block number to local db")
 			}
 		}
@@ -1882,7 +1882,7 @@ func (bc *BlockChain) GetVdfByNumber(number uint64) []byte {
 		return []byte{}
 	}
 
-	return header.Vdf
+	return header.Vdf()
 }
 
 // GetVrfByNumber retrieves the randomness preimage given the block number, return 0 if not exist
@@ -1891,7 +1891,7 @@ func (bc *BlockChain) GetVrfByNumber(number uint64) []byte {
 	if header == nil {
 		return []byte{}
 	}
-	return header.Vrf
+	return header.Vrf()
 }
 
 // GetShardState returns the shard state for the given epoch,
@@ -2117,14 +2117,14 @@ func (bc *BlockChain) WriteCXReceipts(shardID uint32, blockNum uint64, blockHash
 
 // CXMerkleProof calculates the cross shard transaction merkle proof of a given destination shard
 func (bc *BlockChain) CXMerkleProof(shardID uint32, block *types.Block) (*types.CXMerkleProof, error) {
-	proof := &types.CXMerkleProof{BlockNum: block.Number(), BlockHash: block.Hash(), ShardID: block.ShardID(), CXReceiptHash: block.Header().OutgoingReceiptHash, CXShardHashes: []common.Hash{}, ShardIDs: []uint32{}}
+	proof := &types.CXMerkleProof{BlockNum: block.Number(), BlockHash: block.Hash(), ShardID: block.ShardID(), CXReceiptHash: block.Header().OutgoingReceiptHash(), CXShardHashes: []common.Hash{}, ShardIDs: []uint32{}}
 	cxs, err := rawdb.ReadCXReceipts(bc.db, shardID, block.NumberU64(), block.Hash(), false)
 
 	if err != nil || cxs == nil {
 		return nil, err
 	}
 
-	epoch := block.Header().Epoch
+	epoch := block.Header().Epoch()
 	shardingConfig := ShardingSchedule.InstanceForEpoch(epoch)
 	shardNum := int(shardingConfig.NumShards())
 

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -200,7 +200,7 @@ func (c *ChainIndexer) eventLoop(currentHeader *block.Header, events chan ChainH
 	defer sub.Unsubscribe()
 
 	// Fire the initial new head event to start any outstanding processing
-	c.newHead(currentHeader.Number.Uint64(), false)
+	c.newHead(currentHeader.Number().Uint64(), false)
 
 	var (
 		prevHeader = currentHeader
@@ -221,17 +221,17 @@ func (c *ChainIndexer) eventLoop(currentHeader *block.Header, events chan ChainH
 				return
 			}
 			header := ev.Block.Header()
-			if header.ParentHash != prevHash {
+			if header.ParentHash() != prevHash {
 				// Reorg to the common ancestor if needed (might not exist in light sync mode, skip reorg then)
 				// TODO(karalabe, zsfelfoldi): This seems a bit brittle, can we detect this case explicitly?
 
-				if rawdb.ReadCanonicalHash(c.chainDb, prevHeader.Number.Uint64()) != prevHash {
+				if rawdb.ReadCanonicalHash(c.chainDb, prevHeader.Number().Uint64()) != prevHash {
 					if h := rawdb.FindCommonAncestor(c.chainDb, prevHeader, header); h != nil {
-						c.newHead(h.Number.Uint64(), true)
+						c.newHead(h.Number().Uint64(), true)
 					}
 				}
 			}
-			c.newHead(header.Number.Uint64(), false)
+			c.newHead(header.Number().Uint64(), false)
 
 			prevHeader, prevHash = header, header.Hash()
 		}
@@ -404,7 +404,7 @@ func (c *ChainIndexer) processSection(section uint64, lastHead common.Hash) (com
 		header := rawdb.ReadHeader(c.chainDb, hash, number)
 		if header == nil {
 			return common.Hash{}, fmt.Errorf("block #%d [%x…] not found", number, hash[:4])
-		} else if header.ParentHash != lastHead {
+		} else if header.ParentHash() != lastHead {
 			return common.Hash{}, fmt.Errorf("chain reorged during section processing")
 		}
 		if err := c.backend.Process(c.ctx, header); err != nil {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestIsEpochBlock(t *testing.T) {
-	block1 := types.NewBlock(&block.Header{Number: big.NewInt(10)}, nil, nil, nil, nil)
-	block2 := types.NewBlock(&block.Header{Number: big.NewInt(0)}, nil, nil, nil, nil)
-	block3 := types.NewBlock(&block.Header{Number: big.NewInt(344064)}, nil, nil, nil, nil)
-	block4 := types.NewBlock(&block.Header{Number: big.NewInt(77)}, nil, nil, nil, nil)
-	block5 := types.NewBlock(&block.Header{Number: big.NewInt(78)}, nil, nil, nil, nil)
-	block6 := types.NewBlock(&block.Header{Number: big.NewInt(188)}, nil, nil, nil, nil)
-	block7 := types.NewBlock(&block.Header{Number: big.NewInt(189)}, nil, nil, nil, nil)
+	block1 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(10)).Header(), nil, nil, nil, nil)
+	block2 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(0)).Header(), nil, nil, nil, nil)
+	block3 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(344064)).Header(), nil, nil, nil, nil)
+	block4 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(77)).Header(), nil, nil, nil, nil)
+	block5 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(78)).Header(), nil, nil, nil, nil)
+	block6 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(188)).Header(), nil, nil, nil, nil)
+	block7 := types.NewBlock(block.NewHeaderWith().Number(big.NewInt(189)).Header(), nil, nil, nil, nil)
 	tests := []struct {
 		schedule shardingconfig.Schedule
 		block    *types.Block

--- a/core/evm.go
+++ b/core/evm.go
@@ -52,10 +52,10 @@ func NewEVMContext(msg Message, header *block.Header, chain ChainContext, author
 		GetHash:     GetHashFn(header, chain),
 		Origin:      msg.From(),
 		Coinbase:    beneficiary,
-		BlockNumber: new(big.Int).Set(header.Number),
-		Time:        new(big.Int).Set(header.Time),
+		BlockNumber: header.Number(),
+		Time:        header.Time(),
 		//Difficulty:  new(big.Int).Set(header.Difficulty),
-		GasLimit: header.GasLimit,
+		GasLimit: header.GasLimit(),
 		GasPrice: new(big.Int).Set(msg.GasPrice()),
 	}
 }
@@ -68,7 +68,7 @@ func GetHashFn(ref *block.Header, chain ChainContext) func(n uint64) common.Hash
 		// If there's no hash cache yet, make one
 		if cache == nil {
 			cache = map[uint64]common.Hash{
-				ref.Number.Uint64() - 1: ref.ParentHash,
+				ref.Number().Uint64() - 1: ref.ParentHash(),
 			}
 		}
 		// Try to fulfill the request from the cache
@@ -76,10 +76,10 @@ func GetHashFn(ref *block.Header, chain ChainContext) func(n uint64) common.Hash
 			return hash
 		}
 		// Not cached, iterate the blocks and cache the hashes
-		for header := chain.GetHeader(ref.ParentHash, ref.Number.Uint64()-1); header != nil; header = chain.GetHeader(header.ParentHash, header.Number.Uint64()-1) {
-			cache[header.Number.Uint64()-1] = header.ParentHash
-			if n == header.Number.Uint64()-1 {
-				return header.ParentHash
+		for header := chain.GetHeader(ref.ParentHash(), ref.Number().Uint64()-1); header != nil; header = chain.GetHeader(header.ParentHash(), header.Number().Uint64()-1) {
+			cache[header.Number().Uint64()-1] = header.ParentHash()
+			if n == header.Number().Uint64()-1 {
+				return header.ParentHash()
 			}
 		}
 		return common.Hash{}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -245,21 +245,21 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		utils.Logger().Error().Msg("failed to rlp-serialize genesis shard state")
 		os.Exit(1)
 	}
-	head := &block.Header{
-		Number:         new(big.Int).SetUint64(g.Number),
-		Epoch:          big.NewInt(0),
-		ShardID:        g.ShardID,
-		Time:           new(big.Int).SetUint64(g.Timestamp),
-		ParentHash:     g.ParentHash,
-		Extra:          g.ExtraData,
-		GasLimit:       g.GasLimit,
-		GasUsed:        g.GasUsed,
-		MixDigest:      g.Mixhash,
-		Coinbase:       g.Coinbase,
-		Root:           root,
-		ShardStateHash: g.ShardStateHash,
-		ShardState:     shardStateBytes,
-	}
+	head := block.NewHeaderWith().
+		Number(new(big.Int).SetUint64(g.Number)).
+		Epoch(big.NewInt(0)).
+		ShardID(g.ShardID).
+		Time(new(big.Int).SetUint64(g.Timestamp)).
+		ParentHash(g.ParentHash).
+		Extra(g.ExtraData).
+		GasLimit(g.GasLimit).
+		GasUsed(g.GasUsed).
+		MixDigest(g.Mixhash).
+		Coinbase(g.Coinbase).
+		Root(root).
+		ShardStateHash(g.ShardStateHash).
+		ShardState(shardStateBytes).
+		Header()
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 
@@ -280,7 +280,7 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	rawdb.WriteHeadBlockHash(db, block.Hash())
 	rawdb.WriteHeadHeaderHash(db, block.Hash())
 
-	err := rawdb.WriteShardStateBytes(db, block.Header().Epoch, block.Header().ShardState)
+	err := rawdb.WriteShardStateBytes(db, block.Header().Epoch(), block.Header().ShardState())
 
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("Failed to store genesis shard state")

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -350,6 +350,10 @@ func WriteBlock(db DatabaseWriter, block *types.Block) {
 	WriteHeader(db, block.Header())
 	// TODO ek – maybe roll the below into WriteHeader()
 	epoch := block.Header().Epoch()
+	if epoch == nil {
+		// backward compatibility
+		return
+	}
 	epochBlockNum := block.Number()
 	writeOne := func() {
 		if err := WriteEpochBlockNumber(db, epoch, epochBlockNum); err != nil {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -40,18 +40,18 @@ func TestHeaderStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
 
 	// Create a test header to move around the database and make sure it's really new
-	header := &block.Header{Number: big.NewInt(42), Extra: []byte("test header")}
-	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry != nil {
+	header := block.NewHeaderWith().Number(big.NewInt(42)).Extra([]byte("test header")).Header()
+	if entry := ReadHeader(db, header.Hash(), header.Number().Uint64()); entry != nil {
 		t.Fatalf("Non existent header returned: %v", entry)
 	}
 	// Write and verify the header in the database
 	WriteHeader(db, header)
-	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry == nil {
+	if entry := ReadHeader(db, header.Hash(), header.Number().Uint64()); entry == nil {
 		t.Fatalf("Stored header not found")
 	} else if entry.Hash() != header.Hash() {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, header)
 	}
-	if entry := ReadHeaderRLP(db, header.Hash(), header.Number.Uint64()); entry == nil {
+	if entry := ReadHeaderRLP(db, header.Hash(), header.Number().Uint64()); entry == nil {
 		t.Fatalf("Stored header RLP not found")
 	} else {
 		hasher := sha3.NewLegacyKeccak256()
@@ -62,8 +62,8 @@ func TestHeaderStorage(t *testing.T) {
 		}
 	}
 	// Delete the header and verify the execution
-	DeleteHeader(db, header.Hash(), header.Number.Uint64())
-	if entry := ReadHeader(db, header.Hash(), header.Number.Uint64()); entry != nil {
+	DeleteHeader(db, header.Hash(), header.Number().Uint64())
+	if entry := ReadHeader(db, header.Hash(), header.Number().Uint64()); entry != nil {
 		t.Fatalf("Deleted header returned: %v", entry)
 	}
 }
@@ -73,7 +73,7 @@ func TestBodyStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
 
 	// Create a test body to move around the database and make sure it's really new
-	body := &types.Body{Uncles: []*block.Header{{Extra: []byte("test header")}}}
+	body := &types.Body{Uncles: []*block.Header{block.NewHeaderWith().Extra([]byte("test header")).Header()}}
 
 	hasher := sha3.NewLegacyKeccak256()
 	rlp.Encode(hasher, body)
@@ -111,14 +111,14 @@ func TestBlockStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
 
 	// Create a test block to move around the database and make sure it's really new
-	block := types.NewBlockWithHeader(&block.Header{
-		Extra:       []byte("test block"),
-		TxHash:      types.EmptyRootHash,
-		ReceiptHash: types.EmptyRootHash,
-		Epoch:       big.NewInt(0),
-		Number:      big.NewInt(0),
-		ShardState:  []byte("dummy data"),
-	})
+	block := types.NewBlockWithHeader(block.NewHeaderWith().
+		Extra([]byte("test block")).
+		TxHash(types.EmptyRootHash).
+		ReceiptHash(types.EmptyRootHash).
+		Epoch(big.NewInt(0)).
+		Number(big.NewInt(0)).
+		ShardState([]byte("dummy data")).
+		Header())
 	if entry := ReadBlock(db, block.Hash(), block.NumberU64()); entry != nil {
 		t.Fatalf("Non existent block returned: %v", entry)
 	}
@@ -171,11 +171,11 @@ func TestBlockStorage(t *testing.T) {
 // Tests that partial block contents don't get reassembled into full blocks.
 func TestPartialBlockStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
-	block := types.NewBlockWithHeader(&block.Header{
-		Extra:       []byte("test block"),
-		TxHash:      types.EmptyRootHash,
-		ReceiptHash: types.EmptyRootHash,
-	})
+	block := types.NewBlockWithHeader(block.NewHeaderWith().
+		Extra([]byte("test block")).
+		TxHash(types.EmptyRootHash).
+		ReceiptHash(types.EmptyRootHash).
+		Header())
 	// Store a header and check that it's not recognized as a block
 	WriteHeader(db, block.Header())
 	if entry := ReadBlock(db, block.Hash(), block.NumberU64()); entry != nil {
@@ -251,9 +251,9 @@ func TestCanonicalMappingStorage(t *testing.T) {
 func TestHeadStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
 
-	blockHead := types.NewBlockWithHeader(&block.Header{Extra: []byte("test block header")})
-	blockFull := types.NewBlockWithHeader(&block.Header{Extra: []byte("test block full")})
-	blockFast := types.NewBlockWithHeader(&block.Header{Extra: []byte("test block fast")})
+	blockHead := types.NewBlockWithHeader(block.NewHeaderWith().Extra([]byte("test block header")).Header())
+	blockFull := types.NewBlockWithHeader(block.NewHeaderWith().Extra([]byte("test block full")).Header())
+	blockFast := types.NewBlockWithHeader(block.NewHeaderWith().Extra([]byte("test block fast")).Header())
 
 	// Check that no head entries are in a pristine database
 	if entry := ReadHeadHeaderHash(db); entry != (common.Hash{}) {

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -36,7 +36,7 @@ func TestLookupStorage(t *testing.T) {
 	tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), 0, big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 	txs := []*types.Transaction{tx1, tx2, tx3}
 
-	block := types.NewBlock(&block2.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
+	block := types.NewBlock(block2.NewHeaderWith().Number(big.NewInt(314)).Header(), txs, nil, nil, nil)
 
 	// Check that no transactions entries are in a pristine database
 	for i, tx := range txs {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -54,9 +54,9 @@ type testBlockChain struct {
 }
 
 func (bc *testBlockChain) CurrentBlock() *types.Block {
-	return types.NewBlock(&block.Header{
-		GasLimit: bc.gasLimit,
-	}, nil, nil, nil, nil)
+	return types.NewBlock(block.NewHeaderWith().
+		GasLimit(bc.gasLimit).
+		Header(), nil, nil, nil, nil)
 }
 
 func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -96,15 +96,16 @@ func TestBlock_SetLastCommitSig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &Block{header: &block.Header{}}
+			b := &Block{header: block.NewHeader()}
 			b.SetLastCommitSig(tt.sig, tt.signers)
-			if !bytes.Equal(tt.sig, b.header.LastCommitSignature[:]) {
+			sig := b.header.LastCommitSignature()
+			if !bytes.Equal(tt.sig, sig[:]) {
 				t.Errorf("signature mismatch: expected %+v, actual %+v",
-					tt.sig, b.header.LastCommitSignature)
+					tt.sig, sig)
 			}
-			if !bytes.Equal(tt.signers, b.header.LastCommitBitmap) {
+			if !bytes.Equal(tt.signers, b.header.LastCommitBitmap()) {
 				t.Errorf("signature mismatch: expected %+v, actual %+v",
-					tt.signers, b.header.LastCommitBitmap)
+					tt.signers, b.header.LastCommitBitmap())
 			}
 		})
 	}

--- a/core/types/crosslink.go
+++ b/core/types/crosslink.go
@@ -28,12 +28,12 @@ func (cl CrossLink) Header() *block.Header {
 
 // ShardID returns shardID
 func (cl CrossLink) ShardID() uint32 {
-	return cl.ChainHeader.ShardID
+	return cl.ChainHeader.ShardID()
 }
 
 // BlockNum returns blockNum
 func (cl CrossLink) BlockNum() *big.Int {
-	return cl.ChainHeader.Number
+	return cl.ChainHeader.Number()
 }
 
 // Hash returns hash
@@ -43,12 +43,12 @@ func (cl CrossLink) Hash() common.Hash {
 
 // StateRoot returns hash of state root
 func (cl CrossLink) StateRoot() common.Hash {
-	return cl.ChainHeader.Root
+	return cl.ChainHeader.Root()
 }
 
 // OutgoingReceiptsRoot returns hash of cross shard receipts
 func (cl CrossLink) OutgoingReceiptsRoot() common.Hash {
-	return cl.ChainHeader.OutgoingReceiptHash
+	return cl.ChainHeader.OutgoingReceiptHash()
 }
 
 // Serialize returns bytes of cross link rlp-encoded content

--- a/drand/drand_test.go
+++ b/drand/drand_test.go
@@ -128,7 +128,7 @@ func TestVrf(test *testing.T) {
 	tx1 := types.NewTransaction(1, common.BytesToAddress([]byte{0x11}), 0, big.NewInt(111), 1111, big.NewInt(11111), []byte{0x11, 0x11, 0x11})
 	txs := []*types.Transaction{tx1}
 
-	block := types.NewBlock(&block2.Header{Number: big.NewInt(314)}, txs, nil, nil, nil)
+	block := types.NewBlock(block2.NewHeaderWith().Number(big.NewInt(314)).Header(), txs, nil, nil, nil)
 	blockHash := block.Hash()
 
 	dRand.vrf(blockHash)

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -67,7 +67,7 @@ func (b *APIBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.Blo
 	if header == nil || err != nil {
 		return nil, nil, err
 	}
-	stateDb, err := b.hmy.blockchain.StateAt(header.Root)
+	stateDb, err := b.hmy.blockchain.StateAt(header.Root())
 	return stateDb, header, err
 }
 

--- a/hmy/bloombits.go
+++ b/hmy/bloombits.go
@@ -120,7 +120,7 @@ func (b *BloomIndexer) Reset(ctx context.Context, section uint64, lastSectionHea
 // Process implements core.ChainIndexerBackend, adding a new header's bloom into
 // the index.
 func (b *BloomIndexer) Process(ctx context.Context, header *block.Header) error {
-	b.gen.AddBloom(uint(header.Number.Uint64()-b.section*b.size), header.Bloom)
+	b.gen.AddBloom(uint(header.Number().Uint64()-b.section*b.size), header.Bloom())
 	b.head = header.Hash()
 	return nil
 }

--- a/hmyclient/hmyclient.go
+++ b/hmyclient/hmyclient.go
@@ -107,10 +107,10 @@ func (c *Client) getBlock(ctx context.Context, method string, args ...interface{
 		return nil, err
 	}
 	// Quick-verify transaction. This mostly helps with debugging the server.
-	if head.TxHash == types.EmptyRootHash && len(body.Transactions) > 0 {
+	if head.TxHash() == types.EmptyRootHash && len(body.Transactions) > 0 {
 		return nil, fmt.Errorf("server returned non-empty transaction list but block header indicates no transactions")
 	}
-	if head.TxHash != types.EmptyRootHash && len(body.Transactions) == 0 {
+	if head.TxHash() != types.EmptyRootHash && len(body.Transactions) == 0 {
 		return nil, fmt.Errorf("server returned empty transaction list but block header indicates transactions")
 	}
 	// Fill the sender cache of transactions in the block.

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -27,17 +27,17 @@ func (e *engineImpl) SealHash(header *block.Header) (hash common.Hash) {
 	hasher := sha3.NewLegacyKeccak256()
 	// TODO: update with new fields
 	if err := rlp.Encode(hasher, []interface{}{
-		header.ParentHash,
-		header.Coinbase,
-		header.Root,
-		header.TxHash,
-		header.ReceiptHash,
-		header.Bloom,
-		header.Number,
-		header.GasLimit,
-		header.GasUsed,
-		header.Time,
-		header.Extra,
+		header.ParentHash(),
+		header.Coinbase(),
+		header.Root(),
+		header.TxHash(),
+		header.ReceiptHash(),
+		header.Bloom(),
+		header.Number(),
+		header.GasLimit(),
+		header.GasUsed(),
+		header.Time(),
+		header.Extra(),
 	}); err != nil {
 		utils.Logger().Warn().Err(err).Msg("rlp.Encode failed")
 	}
@@ -66,7 +66,7 @@ func (e *engineImpl) Prepare(chain engine.ChainReader, header *block.Header) err
 
 // VerifyHeader checks whether a header conforms to the consensus rules of the bft engine.
 func (e *engineImpl) VerifyHeader(chain engine.ChainReader, header *block.Header, seal bool) error {
-	parentHeader := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
+	parentHeader := chain.GetHeader(header.ParentHash(), header.Number().Uint64()-1)
 	if parentHeader == nil {
 		return engine.ErrUnknownAncestor
 	}
@@ -91,22 +91,22 @@ func (e *engineImpl) VerifyHeaders(chain engine.ChainReader, headers []*block.He
 
 // retrievePublicKeysFromLastBlock finds the public keys of last block's committee
 func retrievePublicKeysFromLastBlock(bc engine.ChainReader, header *block.Header) ([]*bls.PublicKey, error) {
-	parentHeader := bc.GetHeaderByHash(header.ParentHash)
+	parentHeader := bc.GetHeaderByHash(header.ParentHash())
 	if parentHeader == nil {
 		return nil, ctxerror.New("cannot find parent block header in DB",
-			"parentHash", header.ParentHash)
+			"parentHash", header.ParentHash())
 	}
-	parentShardState, err := bc.ReadShardState(parentHeader.Epoch)
+	parentShardState, err := bc.ReadShardState(parentHeader.Epoch())
 	if err != nil {
 		return nil, ctxerror.New("cannot read shard state",
-			"epoch", parentHeader.Epoch,
+			"epoch", parentHeader.Epoch(),
 		).WithCause(err)
 	}
-	parentCommittee := parentShardState.FindCommitteeByID(parentHeader.ShardID)
+	parentCommittee := parentShardState.FindCommitteeByID(parentHeader.ShardID())
 	if parentCommittee == nil {
 		return nil, ctxerror.New("cannot find shard in the shard state",
-			"parentBlockNumber", parentHeader.Number,
-			"shardID", parentHeader.ShardID,
+			"parentBlockNumber", parentHeader.Number(),
+			"shardID", parentHeader.ShardID(),
 		)
 	}
 	var committerKeys []*bls.PublicKey
@@ -125,23 +125,25 @@ func retrievePublicKeysFromLastBlock(bc engine.ChainReader, header *block.Header
 // VerifySeal implements Engine, checking whether the given block satisfies
 // the PoS difficulty requirements, i.e. >= 2f+1 valid signatures from the committee
 func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) error {
-	if chain.CurrentHeader().Number.Uint64() <= uint64(1) {
+	if chain.CurrentHeader().Number().Uint64() <= uint64(1) {
 		return nil
 	}
 	publicKeys, err := retrievePublicKeysFromLastBlock(chain, header)
 	if err != nil {
 		return ctxerror.New("[VerifySeal] Cannot retrieve publickeys from last block").WithCause(err)
 	}
-	payload := append(header.LastCommitSignature[:], header.LastCommitBitmap...)
+	sig := header.LastCommitSignature()
+	payload := append(sig[:], header.LastCommitBitmap()...)
 	aggSig, mask, err := ReadSignatureBitmapByPublicKeys(payload, publicKeys)
 	if err != nil {
 		return ctxerror.New("[VerifySeal] Unable to deserialize the LastCommitSignature and LastCommitBitmap in Block Header").WithCause(err)
 	}
-	parentHeader := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
+	parentHash := header.ParentHash()
+	parentHeader := chain.GetHeader(parentHash, header.Number().Uint64()-1)
 	parentQuorum, err := QuorumForBlock(chain, parentHeader)
 	if err != nil {
 		return errors.Wrapf(err,
-			"cannot calculate quorum for block %s", header.Number)
+			"cannot calculate quorum for block %s", header.Number())
 	}
 	if count := utils.CountOneBits(mask.Bitmap); count < parentQuorum {
 		return ctxerror.New("[VerifySeal] Not enough signature in LastCommitSignature from Block Header",
@@ -149,11 +151,11 @@ func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) 
 	}
 
 	blockNumHash := make([]byte, 8)
-	binary.LittleEndian.PutUint64(blockNumHash, header.Number.Uint64()-1)
-	lastCommitPayload := append(blockNumHash, header.ParentHash[:]...)
+	binary.LittleEndian.PutUint64(blockNumHash, header.Number().Uint64()-1)
+	lastCommitPayload := append(blockNumHash, parentHash[:]...)
 
 	if !aggSig.VerifyHash(mask.AggregatePublic, lastCommitPayload) {
-		return ctxerror.New("[VerifySeal] Unable to verify aggregated signature from last block", "lastBlockNum", header.Number.Uint64()-1, "lastBlockHash", header.ParentHash)
+		return ctxerror.New("[VerifySeal] Unable to verify aggregated signature from last block", "lastBlockNum", header.Number().Uint64()-1, "lastBlockHash", parentHash)
 	}
 	return nil
 }
@@ -166,7 +168,7 @@ func (e *engineImpl) Finalize(chain engine.ChainReader, header *block.Header, st
 	if err := AccumulateRewards(chain, state, header); err != nil {
 		return nil, ctxerror.New("cannot pay block reward").WithCause(err)
 	}
-	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
+	header.SetRoot(state.IntermediateRoot(chain.Config().IsEIP158(header.Number())))
 	return types.NewBlock(header, txs, receipts, outcxs, incxs), nil
 }
 
@@ -174,15 +176,15 @@ func (e *engineImpl) Finalize(chain engine.ChainReader, header *block.Header, st
 func QuorumForBlock(
 	chain engine.ChainReader, h *block.Header,
 ) (quorum int, err error) {
-	ss, err := chain.ReadShardState(h.Epoch)
+	ss, err := chain.ReadShardState(h.Epoch())
 	if err != nil {
 		return 0, errors.Wrapf(err,
-			"cannot read shard state for epoch %s", h.Epoch)
+			"cannot read shard state for epoch %s", h.Epoch())
 	}
-	c := ss.FindCommitteeByID(h.ShardID)
+	c := ss.FindCommitteeByID(h.ShardID())
 	if c == nil {
 		return 0, errors.Errorf(
-			"cannot find shard %d in shard state", h.ShardID)
+			"cannot find shard %d in shard state", h.ShardID())
 	}
 	return (len(c.NodeList))*2/3 + 1, nil
 }

--- a/internal/hmyapi/blockchain.go
+++ b/internal/hmyapi/blockchain.go
@@ -99,7 +99,7 @@ func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address string, bl
 // BlockNumber returns the block number of the chain head.
 func (s *PublicBlockChainAPI) BlockNumber() hexutil.Uint64 {
 	header, _ := s.b.HeaderByNumber(context.Background(), rpc.LatestBlockNumber) // latest header should always be available
-	return hexutil.Uint64(header.Number.Uint64())
+	return hexutil.Uint64(header.Number().Uint64())
 }
 
 // Call executes the given transaction on the state for the given block number.

--- a/internal/hmyapi/filters/filter.go
+++ b/internal/hmyapi/filters/filter.go
@@ -137,7 +137,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	if header == nil {
 		return nil, nil
 	}
-	head := header.Number.Uint64()
+	head := header.Number().Uint64()
 
 	if f.begin == -1 {
 		f.begin = int64(head)
@@ -235,7 +235,7 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64) ([]*types.Log, e
 
 // blockLogs returns the logs matching the filter criteria within a single block.
 func (f *Filter) blockLogs(ctx context.Context, header *block.Header) (logs []*types.Log, err error) {
-	if bloomFilter(header.Bloom, f.addresses, f.topics) {
+	if bloomFilter(header.Bloom(), f.addresses, f.topics) {
 		found, err := f.checkMatches(ctx, header)
 		if err != nil {
 			return logs, err

--- a/internal/hmyapi/filters/filter_system.go
+++ b/internal/hmyapi/filters/filter_system.go
@@ -378,13 +378,13 @@ func (es *EventSystem) lightFilterNewHead(newHeader *block.Header, callBack func
 	// find common ancestor, create list of rolled back and new block hashes
 	var oldHeaders, newHeaders []*block.Header
 	for oldh.Hash() != newh.Hash() {
-		if oldh.Number.Uint64() >= newh.Number.Uint64() {
+		if oldh.Number().Uint64() >= newh.Number().Uint64() {
 			oldHeaders = append(oldHeaders, oldh)
-			oldh = rawdb.ReadHeader(es.backend.ChainDb(), oldh.ParentHash, oldh.Number.Uint64()-1)
+			oldh = rawdb.ReadHeader(es.backend.ChainDb(), oldh.ParentHash(), oldh.Number().Uint64()-1)
 		}
-		if oldh.Number.Uint64() < newh.Number.Uint64() {
+		if oldh.Number().Uint64() < newh.Number().Uint64() {
 			newHeaders = append(newHeaders, newh)
-			newh = rawdb.ReadHeader(es.backend.ChainDb(), newh.ParentHash, newh.Number.Uint64()-1)
+			newh = rawdb.ReadHeader(es.backend.ChainDb(), newh.ParentHash(), newh.Number().Uint64()-1)
 			if newh == nil {
 				// happens when CHT syncing, nothing to do
 				newh = oldh
@@ -403,7 +403,7 @@ func (es *EventSystem) lightFilterNewHead(newHeader *block.Header, callBack func
 
 // filter logs of a single header in light client mode
 func (es *EventSystem) lightFilterLogs(header *block.Header, addresses []common.Address, topics [][]common.Hash, remove bool) []*types.Log {
-	if bloomFilter(header.Bloom, addresses, topics) {
+	if bloomFilter(header.Bloom(), addresses, topics) {
 		// Get the logs of the block
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -92,22 +92,22 @@ type RPCBlock struct {
 func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
-		"number":           (*hexutil.Big)(head.Number),
+		"number":           (*hexutil.Big)(head.Number()),
 		"hash":             b.Hash(),
-		"parentHash":       head.ParentHash,
+		"parentHash":       head.ParentHash(),
 		"nonce":            0, // Remove this because we don't have it in our header
-		"mixHash":          head.MixDigest,
-		"logsBloom":        head.Bloom,
-		"stateRoot":        head.Root,
-		"miner":            head.Coinbase,
+		"mixHash":          head.MixDigest(),
+		"logsBloom":        head.Bloom(),
+		"stateRoot":        head.Root(),
+		"miner":            head.Coinbase(),
 		"difficulty":       0, // Remove this because we don't have it in our header
-		"extraData":        hexutil.Bytes(head.Extra),
+		"extraData":        hexutil.Bytes(head.Extra()),
 		"size":             hexutil.Uint64(b.Size()),
-		"gasLimit":         hexutil.Uint64(head.GasLimit),
-		"gasUsed":          hexutil.Uint64(head.GasUsed),
-		"timestamp":        hexutil.Uint64(head.Time.Uint64()),
-		"transactionsRoot": head.TxHash,
-		"receiptsRoot":     head.ReceiptHash,
+		"gasLimit":         hexutil.Uint64(head.GasLimit()),
+		"gasUsed":          hexutil.Uint64(head.GasUsed()),
+		"timestamp":        hexutil.Uint64(head.Time().Uint64()),
+		"transactionsRoot": head.TxHash(),
+		"receiptsRoot":     head.ReceiptHash(),
 	}
 
 	if inclTx {

--- a/node/node.go
+++ b/node/node.go
@@ -340,7 +340,7 @@ func (node *Node) StartServer() {
 // Currently used for stats reporting purpose
 func (node *Node) countNumTransactionsInBlockchain() int {
 	count := 0
-	for block := node.Blockchain().CurrentBlock(); block != nil; block = node.Blockchain().GetBlockByHash(block.Header().ParentHash) {
+	for block := node.Blockchain().CurrentBlock(); block != nil; block = node.Blockchain().GetBlockByHash(block.Header().ParentHash()) {
 		count += len(block.Transactions())
 	}
 	return count

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -147,7 +147,7 @@ func (node *Node) proposeShardStateWithoutBeaconSync(block *types.Block) error {
 	if block == nil || !core.IsEpochLastBlock(block) {
 		return nil
 	}
-	nextEpoch := new(big.Int).Add(block.Header().Epoch, common.Big1)
+	nextEpoch := new(big.Int).Add(block.Header().Epoch(), common.Big1)
 	shardState := core.GetShardState(nextEpoch)
 	return block.AddShardState(shardState)
 }
@@ -168,7 +168,7 @@ func (node *Node) proposeBeaconShardState(block *types.Block) error {
 		// We haven't reached the end of this epoch; don't propose yet.
 		return nil
 	}
-	nextEpoch := new(big.Int).Add(block.Header().Epoch, common.Big1)
+	nextEpoch := new(big.Int).Add(block.Header().Epoch(), common.Big1)
 	shardState, err := core.CalculateNewShardState(
 		node.Blockchain(), nextEpoch, &node.CurrentStakes)
 	if err != nil {

--- a/shard/shard_state.go
+++ b/shard/shard_state.go
@@ -174,8 +174,8 @@ func GetHashFromNodeList(nodeList []NodeID) []byte {
 	}
 
 	d := sha3.NewLegacyKeccak256()
-	for i := range nodeList {
-		d.Write(nodeList[i].Serialize())
+	for _, nodeID := range nodeList {
+		d.Write(nodeID.Serialize())
 	}
 	return d.Sum(nil)
 }


### PR DESCRIPTION
This is *mostly* a refactor.  It hides `block.Header` fields behind a private struct, and exposes the fields using field accessor methods (getters/setters).

Call sites using header field values have been modified to use getters (by simply appending the field selector with parentheses, compliant with Effective Go recommendation that getters be named after the field they are exposing, without a `Get` prefix).  Call sites *modifying* header field values directly have been retrofitted to use setters.  Some call sites that used to modify a header field by passing it by reference to another function (such as `GasUsed` calculation) now use a get-modify-set pattern.

The getters/setters protect the real header field value stored within the private struct by making a copy wherever needed.  This rule applies to `big.Int` pointers and `[]byte` slices.  This full protection also makes it possible to copy header by value without having to clone `big.Int` instances or `[]byte` slices.

Unit test still passes, and local test reaches consensus.
